### PR TITLE
修复幻灯片播放结束后继续点击下一页出现没有正在播放幻灯片的异常

### DIFF
--- a/DemoApp/PhoneAsPrompter/FormMain.cs
+++ b/DemoApp/PhoneAsPrompter/FormMain.cs
@@ -70,6 +70,7 @@ namespace PhoneAsPrompter
                 var request = context.Request;
                 var response = context.Response;
                 string path = request.Path.Value;
+                bool hasRun = true;
                 if (path == "/getNote")
                 {
                     response.StatusCode = 200;
@@ -100,9 +101,25 @@ namespace PhoneAsPrompter
                         {
                             return;
                         }
-                        T(T(this.presentation.SlideShowWindow).View).Next();
+                        try
+                        {
+                            T(T(this.presentation.SlideShowWindow).View).Next();
+                            hasRun = true;
+                        }
+                        catch(COMException e)
+                        {
+                            hasRun = false;
+                        }
+                        
                     }));
-                    await response.WriteAsync("OK");
+                    if (hasRun)
+                    {
+                        await response.WriteAsync("OK");
+                    }
+                    else
+                    {
+                        await response.WriteAsync("NO");
+                    }
                 }
                 else if (path == "/previous")
                 {
@@ -112,9 +129,25 @@ namespace PhoneAsPrompter
                         {
                             return;
                         }
-                        T(T(this.presentation.SlideShowWindow).View).Previous();
+                        try
+                        {
+                            T(T(this.presentation.SlideShowWindow).View).Previous();
+                            hasRun = true;
+                        }
+                        catch (COMException e)
+                        {
+                            hasRun = false;
+                        }
                     }));
-                    await response.WriteAsync("OK");
+                    if (hasRun)
+                    {
+                        await response.WriteAsync("OK");
+                    }
+                    else
+                    {
+                        await response.WriteAsync("NO");
+                    }
+                    
                 }
                 else
                 {

--- a/DemoApp/PhoneAsPrompter/wwwroot/index.html
+++ b/DemoApp/PhoneAsPrompter/wwwroot/index.html
@@ -14,17 +14,28 @@
 
     </div>
     <script type="text/javascript">
-        setInterval(function () {
+        const note = document.querySelector("#divNote");
+        let getNote = setInterval(function () {
             axios.post("/getNote").then(function (resp) {
-                document.getElementById("divNote").innerHTML =resp.data;
+                note.innerText =resp.data;
             });
         }, 300);
-        var hammer = new Hammer(document.getElementById("divNote"));
+        var hammer = new Hammer(note);
         hammer.on("swipeleft", function () {
-            axios.post("/next");
+            axios.post("/next").then((text) => {
+                if (text.data == 'NO') {
+                    note.innerText = '幻灯片播放结束！'
+                    clearInterval(getNote)
+                }
+            });
         });
         hammer.on("swiperight", function () {
-            axios.post("/previous");
+            axios.post("/previous").then((text) => {
+                if (text.data == 'NO') {
+                    note.innerText = '幻灯片播放结束！'
+                    clearInterval(getNote)
+                }
+            });
         });
     </script>
 </body>


### PR DESCRIPTION
修复上一页和下一页操作没有try catch，导致在幻灯片结束后，如果继续进行下一页操作，就会出现没有正在播放的幻灯片异常。

在前端页面增加了幻灯片 播放结束后的提示消息